### PR TITLE
Allow gridster to draw widgets larger than 5 columns

### DIFF
--- a/assets/javascripts/application.coffee
+++ b/assets/javascripts/application.coffee
@@ -23,6 +23,7 @@ Dashing.on 'ready', ->
       widget_margins: Dashing.widget_margins
       widget_base_dimensions: Dashing.widget_base_dimensions
       avoid_overlapped_widgets: !Dashing.customGridsterLayout
+      max_size_x: Dashing.numColumns
       draggable:
         stop: Dashing.showGridsterInstructions
         start: -> Dashing.currentWidgetPositions = Dashing.getWidgetPositions()


### PR DESCRIPTION
Default application.coffee gridster code doesn't behave properly when trying to size widgets over 5 columns wide.  This addition allows gridster to properly size over the total number of columns specified.
