### PR TITLE
Fix NoMethodError if devicetracker not avaliable.

### DIFF
--- a/jobs/homeassistant.rb
+++ b/jobs/homeassistant.rb
@@ -220,8 +220,8 @@ get '/homeassistant/devicetracker' do
 	else
 		state = response["state"]
 	end
-
-	return JSON.generate({"state" => state.upcase})
+	state = state.nil? ? "unknown" : state.upcase
+	return JSON.generate({"state" => state})
 end
 
 post '/homeassistant/devicetracker' do


### PR DESCRIPTION
Resolving issues where the state may not be set to a string if the tracker name is wrong. 

2016-12-07 18:01:19 - NoMethodError - undefined method `upcase' for nil:NilClass:
        /app/jobs/homeassistant.rb:224:in `block in <top (required)>'
        /usr/local/bundle/gems/sinatra-1.4.7/lib/sinatra/base.rb:1611:in `call'